### PR TITLE
Add amount of total hours to worklog dump

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,4 +182,9 @@ function dumpWorklog(worklog, console) {
       ].join("\t")
     )
     .map(log => console.log(log));
+
+  totalMins = worklog.reduce(function (pre, cur) { return pre + parseInt(cur.timeInMinutes); }, 0);
+  totalHours = totalMins / 60
+
+  console.log("Total hours: " + totalHours);
 }


### PR DESCRIPTION
When you run this app on the commandline the output is now:

```
3 entries:
PREFIX-123  30 min  Some work
PREFIX-132  90 min  Some other work
PREFIX-321  75 min  Some other other work
Total hours: 3.25
? Does this look alright? (Y/n)
```
